### PR TITLE
feat: allow dynamic LinkedIn author URN

### DIFF
--- a/components/PostComposer.tsx
+++ b/components/PostComposer.tsx
@@ -22,7 +22,10 @@ export default function PostComposer() {
     const dummyToken = '';
     try {
       if (dest.linkedin)
-        await postToLinkedIn({ accessToken: dummyToken, content: text });
+        await postToLinkedIn(
+          { accessToken: dummyToken, content: text },
+          'urn:li:person:me'
+        );
       if (dest.instagram)
         await postToInstagram({ accessToken: dummyToken, content: text });
       setText('');

--- a/libs/socialIntegrations.ts
+++ b/libs/socialIntegrations.ts
@@ -46,7 +46,8 @@ export async function exchangeLinkedInCode(params: {
 }
 
 export async function postToLinkedIn(
-  payload: CrossPostPayload
+  payload: CrossPostPayload,
+  authorUrn: string
 ): Promise<unknown> {
   const res = await fetch('https://api.linkedin.com/v2/ugcPosts', {
     method: 'POST',
@@ -56,7 +57,7 @@ export async function postToLinkedIn(
       'X-Restli-Protocol-Version': '2.0.0',
     },
     body: JSON.stringify({
-      author: 'urn:li:person:me',
+      author: authorUrn,
       lifecycleState: 'PUBLISHED',
       specificContent: {
         'com.linkedin.ugc.ShareContent': {


### PR DESCRIPTION
## Summary
- allow specifying the LinkedIn author URN when posting
- pass a placeholder LinkedIn URN from the PostComposer component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a7a5b4f2c83218d5b3aebc0897a35