### PR TITLE
Add social auth context and post notifications

### DIFF
--- a/components/PostComposer.tsx
+++ b/components/PostComposer.tsx
@@ -9,6 +9,7 @@ import {
   postToInstagram,
   postToLinkedIn,
 } from '@/libs/socialIntegrations';
+import { useSocialAuth } from '@/lib/socialAuth';
 
 export default function PostComposer() {
   const [text, setText] = useState('');
@@ -16,18 +17,25 @@ export default function PostComposer() {
     linkedin: false,
     instagram: false,
   });
+  const { linkedinToken, instagramToken } = useSocialAuth();
 
   const submit = async () => {
-    // Placeholder access tokens; production would obtain via OAuth.
-    const dummyToken = '';
     try {
       if (dest.linkedin)
-        await postToLinkedIn({ accessToken: dummyToken, content: text });
+        await postToLinkedIn({
+          accessToken: linkedinToken ?? '',
+          content: text,
+        });
       if (dest.instagram)
-        await postToInstagram({ accessToken: dummyToken, content: text });
+        await postToInstagram({
+          accessToken: instagramToken ?? '',
+          content: text,
+        });
       setText('');
+      alert('Post sent successfully');
     } catch (err) {
       console.error(err);
+      alert('Failed to send post');
     }
   };
 

--- a/lib/socialAuth.tsx
+++ b/lib/socialAuth.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, ReactNode } from 'react';
+
+export type SocialAuthTokens = {
+  linkedinToken?: string;
+  instagramToken?: string;
+};
+
+const SocialAuthContext = createContext<SocialAuthTokens>({});
+
+export function SocialAuthProvider({
+  children,
+  linkedinToken,
+  instagramToken,
+}: SocialAuthTokens & { children: ReactNode }) {
+  return (
+    <SocialAuthContext.Provider value={{ linkedinToken, instagramToken }}>
+      {children}
+    </SocialAuthContext.Provider>
+  );
+}
+
+export function useSocialAuth() {
+  return useContext(SocialAuthContext);
+}
+


### PR DESCRIPTION
## Summary
- provide social auth context hook to supply LinkedIn and Instagram OAuth tokens
- use context tokens in PostComposer and show success/error alerts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a7a6971c88321ac4f1642f5995f7c